### PR TITLE
Update go.mod to reflect actual URL

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,1 @@
-module github.com/google/uuid
+module github.com/getlantern/uuid


### PR DESCRIPTION
I am in the process of converting some (possibly all) Lantern repos to Go modules.  If a repo depends on this library, the Go tool will attempt to download this repo.  The tool will navigate to this URL, see an improper go.mod file, and fail.

Alternatively, I can try using replace directives so that projects import google/uuid, but the Go tool actually downloads getlantern/uuid.  However, it looks like at least some projects currently import getlantern/uuid.  Also, I'm not sure the replace directive would solve the issue.